### PR TITLE
pytest: move test spec wrapper class defs to fixture functions (with fixture collector)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -158,7 +158,10 @@ def fixture_collector(request):
     Returns the configured fixture collector instance used for all tests
     in one test module.
     """
-    yield FixtureCollector(output_dir=request.config.getoption("output"))
+    fixture_collector = FixtureCollector(
+        output_dir=request.config.getoption("output")
+    )
+    yield fixture_collector
     fixture_collector.dump_fixtures()
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -199,7 +199,9 @@ def reference_spec():
 
 
 @pytest.fixture(scope="function")
-def state_test() -> StateTestFiller:
+def state_test(
+    request, t8n, b11r, fork, engine, reference_spec, eips, fixture_collector
+) -> StateTestFiller:
     """
     Fixture used to instantiate an auto-fillable StateTest object from within
     a test function.
@@ -210,19 +212,32 @@ def state_test() -> StateTestFiller:
 
     Implementation detail: It must be scoped on test function level to avoid
     leakage between tests.
-
-    Proper definition of the StateTestWrapper is done during the
-    pytest_runtest_call.
     """
 
     class StateTestWrapper(StateTest):
-        pass
+        def __init__(self, *args, **kwargs):
+            super(StateTestWrapper, self).__init__(*args, **kwargs)
+            fixture_collector.add_fixture(
+                request.node,
+                fill_test(
+                    "",
+                    t8n,
+                    b11r,
+                    self,
+                    fork,
+                    engine,
+                    reference_spec,
+                    eips=eips,
+                ),
+            )
 
     return StateTestWrapper
 
 
 @pytest.fixture(scope="function")
-def blockchain_test() -> BlockchainTestFiller:
+def blockchain_test(
+    request, t8n, b11r, fork, engine, reference_spec, eips, fixture_collector
+) -> BlockchainTestFiller:
     """
     Fixture used to define an auto-fillable BlockchainTest analogous to the
     state_test fixture for StateTests.
@@ -230,7 +245,21 @@ def blockchain_test() -> BlockchainTestFiller:
     """
 
     class BlockchainTestWrapper(BlockchainTest):
-        pass
+        def __init__(self, *args, **kwargs):
+            super(BlockchainTestWrapper, self).__init__(*args, **kwargs)
+            fixture_collector.add_fixture(
+                request.node,
+                fill_test(
+                    "",
+                    t8n,
+                    b11r,
+                    self,
+                    fork,
+                    engine,
+                    reference_spec,
+                    eips=eips,
+                ),
+            )
 
     return BlockchainTestWrapper
 
@@ -243,70 +272,14 @@ def pytest_make_parametrize_id(config, val, argname):
     return f"{argname}={val}"
 
 
-@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     """
-    Pytest hook called in the context of test execution. After pytest
-    has executed the test function and created the test spec, we fill
-    the test spec and write the generated fixture to file.
+    Pytest hook called in the context of test execution.
     """
-
-    # Get config from session-wide fixtures. Note, we could also access these
-    # from the pytest config object via item.config
-    # evm_bin = item.funcargs["evm_bin"]
+    # Get current test item from session-wide and locally scoped fixtures.
     t8n = item.funcargs["t8n"]
-    b11r = item.funcargs["b11r"]
-    engine = item.funcargs["engine"]
-    reference_spec = item.funcargs["reference_spec"]
-    fixture_collector: FixtureCollector = item.funcargs["fixture_collector"]
-
-    # Get test-specific params from potentially locally defined fixtures
-    eips = item.funcargs["eips"]
     fork = item.funcargs["fork"]
-
     if not t8n.is_fork_supported(fork):
         pytest.skip(f"Fork '{fork}' not supported by t8n, skipped")
     if fork == ArrowGlacier:
         pytest.skip(f"Fork '{fork}' not supported by hive, skipped")
-
-    spec_types: Dict[str, Type] = {
-        "state_test": StateTest,
-        "blockchain_test": BlockchainTest,
-    }
-
-    spec_type_count = 0
-    for spec_type, spec_class in spec_types.items():
-        if spec_type in item.funcargs:
-            spec_type_count += 1
-
-            class AutoFillerWrapper(spec_class):
-                def __init__(self, *args, **kwargs):
-                    super(AutoFillerWrapper, self).__init__(*args, **kwargs)
-                    fixture_collector.add_fixture(
-                        item,
-                        fill_test(
-                            "",
-                            t8n,
-                            b11r,
-                            self,
-                            fork,
-                            engine,
-                            reference_spec,
-                            eips=eips,
-                        ),
-                    )
-
-            item.funcargs[spec_type] = AutoFillerWrapper
-
-    if spec_type_count == 0:
-        raise Exception(
-            "Test function must define at least one of the following spec "
-            + "type arguments: "
-            + ", ".join(spec_types.keys())
-        )
-
-    output = yield  # Execute the test function
-
-    # Process test result; this will stop execution if there was an issue in
-    # the test function and trigger a pytest error or fail for this spec.
-    output.get_result()

--- a/conftest.py
+++ b/conftest.py
@@ -160,8 +160,8 @@ def fixture_collector(request):
     fixture_collector = FixtureCollector(
         output_dir=request.config.getoption("output")
     )
-    request.addfinalizer(fixture_collector.dump_fixtures)
-    return fixture_collector
+    yield fixture_collector
+    fixture_collector.dump_fixtures()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/conftest.py
+++ b/conftest.py
@@ -152,10 +152,11 @@ class FixtureCollector:
                 json.dump(output_json, f, indent=4)
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(scope="module")
 def fixture_collector(request):
     """
-    Returns the configured fixture collector instance used for all tests.
+    Returns the configured fixture collector instance used for all tests
+    in one test module.
     """
     yield FixtureCollector(output_dir=request.config.getoption("output"))
     fixture_collector.dump_fixtures()

--- a/conftest.py
+++ b/conftest.py
@@ -157,10 +157,7 @@ def fixture_collector(request):
     """
     Returns the configured fixture collector instance used for all tests.
     """
-    fixture_collector = FixtureCollector(
-        output_dir=request.config.getoption("output")
-    )
-    yield fixture_collector
+    yield FixtureCollector(output_dir=request.config.getoption("output"))
     fixture_collector.dump_fixtures()
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -146,7 +146,7 @@ class FixtureCollector:
                 name, fixture = name_fixture
                 name = str(index).zfill(3) + "-" + name
                 output_json[name] = fixture
-            file_path = self.output_dir + module_file + ".json"
+            file_path = self.output_dir + os.sep + module_file + ".json"
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, "w") as f:
                 json.dump(output_json, f, indent=4)

--- a/fillers/eips/eip3651.py
+++ b/fillers/eips/eip3651.py
@@ -130,7 +130,7 @@ def test_warm_coinbase_call_out_of_gas(
             }
         )
 
-    state_test.spec = StateTest(
+    state_test(
         env=env,
         pre=pre,
         post=post,
@@ -254,7 +254,7 @@ def test_warm_coinbase_gas_usage(state_test, fork, opcode, code_gas_measure):
         protected=False,
     )
 
-    state_test.spec = StateTest(
+    state_test(
         env=env,
         pre=pre,
         post=post,

--- a/fillers/eips/eip3855.py
+++ b/fillers/eips/eip3855.py
@@ -70,9 +70,7 @@ def test_push0_key_sstore(
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x01})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="key_sstore"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="key_sstore")
 
 
 def test_push0_fill_stack(
@@ -94,9 +92,7 @@ def test_push0_fill_stack(
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x01})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="fill_stack"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="fill_stack")
 
 
 def test_push0_stack_overflow(
@@ -117,9 +113,7 @@ def test_push0_stack_overflow(
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x00})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="stack_overflow"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="stack_overflow")
 
 
 def test_push0_storage_overwrite(
@@ -139,9 +133,7 @@ def test_push0_storage_overwrite(
     pre[addr_1] = Account(code=code, storage={0x00: 0x0A, 0x01: 0x0A})
     post[addr_1] = Account(storage={0x00: 0x02, 0x01: 0x00})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="storage_overwrite"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="storage_overwrite")
 
 
 def test_push0_during_staticcall(
@@ -175,9 +167,7 @@ def test_push0_during_staticcall(
     pre[addr_2] = Account(code=code_2)
     post[addr_1] = Account(storage={0x00: 0x01, 0x01: 0xFF})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="during_staticcall"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="during_staticcall")
 
 
 def test_push0_before_jumpdest(
@@ -204,9 +194,7 @@ def test_push0_before_jumpdest(
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x01})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="before_jumpdest"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="before_jumpdest")
 
 
 def test_push0_gas_cost(
@@ -229,6 +217,4 @@ def test_push0_gas_cost(
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x02})
 
-    state_test.spec = StateTest(
-        env=env, pre=pre, post=post, txs=[tx], tag="gas_cost"
-    )
+    state_test(env=env, pre=pre, post=post, txs=[tx], tag="gas_cost")

--- a/fillers/vm/chain_id.py
+++ b/fillers/vm/chain_id.py
@@ -50,4 +50,4 @@ def test_chain_id(state_test, fork):
         ),
     }
 
-    state_test.spec = StateTest(env=env, pre=pre, post=post, txs=[tx])
+    state_test(env=env, pre=pre, post=post, txs=[tx])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,5 @@ line-length = 79
 [tool.pytest.ini_options]
 console_output_style = "count"
 minversion = "7.0"
-testpaths = ["fillers/example"]
+testpaths = ["fillers/example", "fillers/eips/eip3651.py", "fillers/eips/eip3855.py", "fillers/vm/chain_id.py"]
 python_files = "*.py"


### PR DESCRIPTION
This PR supercedes #4.

Changes in this PR:
- Moves the spec test class wrapper definitions from the `pytest_runtest_call` hook to the fixture definitions (I think defining the wrappers directly in the fixtures is more logical and closer to standard pytest use). This change is also implemented in #4, which is based on older branch).
- Minor fix: Fix the directory output path (838881e00b0cbcb91874d836e42bab8c7286588d)
- Minor style improvement: Use a yield-type fixture for the fixture_collector fixture(0bca15e73da9661ba5a9a36282c8d932dadb29b4).
- Port all converted state test fillers to the new `state_test` (auto-filling upon instantiation) format.
- Add all converted state test fillers to pytest's `testpaths` config, so they all (34 test cases) get executed when `pytest` is called.
- Change scope of the `fixture_collector` pytest fixture from session to module.