### PR TITLE
framework: test the withdrawals root in t8n's output result

### DIFF
--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -10,7 +10,19 @@ from typing import Any, Callable, Dict, Generator, Iterator, List, Mapping, Opti
 from ethereum_test_forks import Fork
 from evm_transition_tool import TransitionTool
 
-from ..common import Account, Address, Alloc, Bytes, FixtureBlock, FixtureHeader, Hash, Transaction
+from ..common import (
+    Account,
+    Address,
+    Alloc,
+    Bytes,
+    Environment,
+    FixtureBlock,
+    FixtureHeader,
+    Hash,
+    Transaction,
+    withdrawals_root,
+)
+from ..common.conversions import to_hex
 
 
 def verify_transactions(txs: List[Transaction] | None, result) -> List[int]:
@@ -57,6 +69,15 @@ def verify_post_alloc(expected_post: Mapping, got_alloc: Mapping):
                     account.check_alloc(address, got_alloc_normalized[address])
                 else:
                     raise Exception(f"expected account not found: {address}")
+
+
+def verify_result(result: Mapping, env: Environment):
+    """
+    Verify that values in the t8n result match the expected values.
+    Raises exception on unexpected values.
+    """
+    if env.withdrawals is not None:
+        assert result["withdrawalsRoot"] == to_hex(withdrawals_root(env.withdrawals))
 
 
 @dataclass(kw_only=True)

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -28,7 +28,7 @@ from ..common import (
     withdrawals_root,
 )
 from ..common.constants import EmptyOmmersRoot
-from .base_test import BaseTest, verify_post_alloc, verify_transactions
+from .base_test import BaseTest, verify_post_alloc, verify_result, verify_transactions
 from .debugging import print_traces
 
 
@@ -164,6 +164,7 @@ class BlockchainTest(BaseTest):
             )
             try:
                 rejected_txs = verify_transactions(txs, result)
+                verify_result(result, env)
             except Exception as e:
                 print_traces(t8n.get_traces())
                 pprint(result)

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -27,7 +27,7 @@ from ..common import (
     withdrawals_root,
 )
 from ..common.constants import EmptyOmmersRoot, EngineAPIError
-from .base_test import BaseTest, verify_post_alloc, verify_transactions
+from .base_test import BaseTest, verify_post_alloc, verify_result, verify_transactions
 from .debugging import print_traces
 
 
@@ -148,6 +148,7 @@ class StateTest(BaseTest):
 
         try:
             verify_post_alloc(self.post, alloc)
+            verify_result(result, env)
         except Exception as e:
             print_traces(traces=t8n.get_traces())
             raise e


### PR DESCRIPTION
We could add this check for free now.