### PR TITLE
feat(pytest): allow filtering by fixture format via pytest mark

### DIFF
--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -144,7 +144,7 @@ class BaseTest:
     tag: str = ""
     # Setting a default here is just for type checking, the correct value is automatically set
     # by pytest.
-    fixture_format: FixtureFormats = FixtureFormats.UNSET
+    fixture_format: FixtureFormats = FixtureFormats.UNSET_TEST_FORMAT
 
     # Transition tool specific fields
     t8n_dump_dir: Optional[str] = ""

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -40,7 +40,7 @@ class FixtureFormats(Enum):
     Helper class to define fixture formats.
     """
 
-    UNSET = "unset"
+    UNSET_TEST_FORMAT = "unset_test_format"
     STATE_TEST = "state_test"
     STATE_TEST_HIVE = "state_test_hive"
     BLOCKCHAIN_TEST = "blockchain_test"
@@ -73,7 +73,7 @@ class FixtureFormats(Enum):
 
         Used to add a description to the generated pytest marks.
         """
-        if format == cls.UNSET:
+        if format == cls.UNSET_TEST_FORMAT:
             return "Unknown fixture format; it has not been set."
         elif format == cls.STATE_TEST:
             return "Tests that generate a state test fixture."

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -66,6 +66,25 @@ class FixtureFormats(Enum):
     def is_verifiable(cls, format):  # noqa: D102
         return format in (cls.STATE_TEST, cls.BLOCKCHAIN_TEST)
 
+    @classmethod
+    def get_format_description(cls, format):
+        """
+        Returns a description of the fixture format.
+
+        Used to add a description to the generated pytest marks.
+        """
+        if format == cls.UNSET:
+            return "Unknown fixture format; it has not been set."
+        elif format == cls.STATE_TEST:
+            return "Tests that generate a state test fixture."
+        elif format == cls.STATE_TEST_HIVE:
+            return "Tests that generate a state test fixture in hive format."
+        elif format == cls.BLOCKCHAIN_TEST:
+            return "Tests that generate a blockchain test fixture."
+        elif format == cls.BLOCKCHAIN_TEST_HIVE:
+            return "Tests that generate a blockchain test fixture in hive format."
+        raise Exception(f"Unknown fixture format: {format}.")
+
 
 class TransitionTool:
     """


### PR DESCRIPTION
Adds the following markers (output of `fill --markers`):
```
@pytest.mark.unset_test_format: Unknown fixture format; it has not been set.

@pytest.mark.state_test: Tests that generate a state test fixture.

@pytest.mark.state_test_hive: Tests that generate a state test fixture in hive format.

@pytest.mark.blockchain_test: Tests that generate a blockchain test fixture.

@pytest.mark.blockchain_test_hive: Tests that generate a blockchain test fixture in hive format.
```

so that tests can be filtered by the type of test fixture they generate.