### PR TITLE
feat(pytest): only paramatrize post-merge forks with hive format

### DIFF
--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 from pprint import pprint
 from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Tuple, Type
 
-import pytest
-
 from ethereum_test_forks import Fork
 from evm_transition_tool import FixtureFormats, TransitionTool
 
@@ -393,7 +391,10 @@ class BlockchainTest(BaseTest):
         t8n.reset_traces()
         if self.fixture_format == FixtureFormats.BLOCKCHAIN_TEST_HIVE:
             if fork.engine_forkchoice_updated_version() is None:
-                pytest.skip("Hive fixture requested but no forkchoice update is defined")
+                raise Exception(
+                    "Hive fixture requested but no forkchoice update is defined."
+                    "This test case should never have been executed."
+                )
             return self.make_hive_fixture(t8n, fork, eips)
         elif self.fixture_format == FixtureFormats.BLOCKCHAIN_TEST:
             return self.make_fixture(t8n, fork, eips)

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -392,8 +392,8 @@ class BlockchainTest(BaseTest):
         if self.fixture_format == FixtureFormats.BLOCKCHAIN_TEST_HIVE:
             if fork.engine_forkchoice_updated_version() is None:
                 raise Exception(
-                    "Hive fixture requested but no forkchoice update is defined."
-                    "This test case should never have been executed."
+                    "A hive fixture was requested but no forkchoice update is defined. "
+                    "The framework should never try to execute this test case."
                 )
             return self.make_hive_fixture(t8n, fork, eips)
         elif self.fixture_format == FixtureFormats.BLOCKCHAIN_TEST:


### PR DESCRIPTION
Remove test parametrizations for the case of pre-merge forks and `BLOCKCHAIN_TEST_HIVE` or `STATE_TEST_HIVE` fixture formats. 

This removes unnecessary node ids that will always be marked to skip as it's an invalid/unnecessary parameter combination.