### PR TITLE
fix(fw): fix dump-dir for state tests in blockchain test format

### DIFF
--- a/src/ethereum_test_tools/spec/state/state_test.py
+++ b/src/ethereum_test_tools/spec/state/state_test.py
@@ -96,6 +96,7 @@ class StateTest(BaseTest):
             post=self.post,
             blocks=self._generate_blockchain_blocks(),
             fixture_format=self.fixture_format,
+            t8n_dump_dir=self.t8n_dump_dir,
         )
 
     def make_state_test_fixture(


### PR DESCRIPTION
`tests/berlin/eip2930_access_list/test_acl.py::test_access_list` is a `StateTest`.

Before:
![image](https://github.com/marioevz/execution-spec-tests/assets/91727015/6076f57b-04ab-4221-a7b4-fcf66c268693)

After:
![image](https://github.com/marioevz/execution-spec-tests/assets/91727015/ec990718-3752-4388-871a-dd6218793b4f)

### but this is a feature, not a bug

Our 1-to-1 mappings of test-to-json-fixture makes less sense for the evm debug directory, as we write identical (t8n) debug info to multiple directories. However, without this fix, no evm-dump-dir will be created at all if only the blockchain test format is generated from a state test:
![image](https://github.com/marioevz/execution-spec-tests/assets/91727015/09571d9c-f857-4762-8b5b-7f99bf80213c)


I think this duplication is acceptable. It's certainly less confusing than trying to create a single dump dir for multiple fixture formats (respectively tests), but open to ideas. Mainly think this is acceptable because the `--evm-dump-dir` flag is purely a debug flag and should be used sparingly.